### PR TITLE
bugfix: removing single star from end of cell values if it exists

### DIFF
--- a/code/ingest.py
+++ b/code/ingest.py
@@ -151,6 +151,8 @@ def validate(table):
             assert "New staff" in row[1]
             assert "New student" in row[2]
             continue
+
+        row = [cell_value[:-1] if cell_value.endswith('*') else cell_value for cell_value in row]
         validated.append(row)
 
     return validated


### PR DESCRIPTION
Technically it looks for and removes one star from the end of a cell, but doesn't confirm it's the only star that existed.
And it also checks all columns rather than just the two we can currently see stars in.

I thought this was fine. Mention if too liberal. 


